### PR TITLE
fix: remove erroneous attribute setting

### DIFF
--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -19,11 +19,6 @@ resource "aws_iam_role_policy" "codebuild_policy" {
     environment        = var.environment,
     function_prefix    = var.function_prefix
   })
-  tags = {
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
 }
 
 resource "aws_iam_role_policy" "codebuild_policy_2" {


### PR DESCRIPTION
The aws_iam_role_policy resource does not accept the tags attribute.

Remove it.