### PR TITLE
chore: Added a default server_side_encryption_configuration configuration to function_codebuild_cache bucket

### DIFF
--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -56,6 +56,17 @@ resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
   acl    = "private"
 
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = ""
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags = {
     Name        = "${var.function_name} ${var.environment} CodeBuild cache"
     Platform    = var.platform


### PR DESCRIPTION
- Added a default server_side_encryption_configuration configuration block to avoid constant pipeline changes e.g. https://app.terraform.io/app/Immediate-Media/workspaces/wcp-services-apps-pipelines/runs/run-bJdFZ5BjW8AjRfUT

ticket: N/A
branch: chore/add-bucket-encryption-default