### PR TITLE
feature/FAB-51316 Define default fallback for codebuild version

### DIFF
--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -24,6 +24,8 @@ variable "environment" {
 
 variable "environment_image" {
   description = "Which Docker image to use as your build environment"
+  type        = string
+  default     = "aws/codebuild/standard:5.0"
 }
 
 variable "environment_variables" {


### PR DESCRIPTION
NB: Using 5.0 as thats what all downstream were using, we should shift to 7.0 once we've got this working.