### PR TITLE
fix: remove bucket ACLs

### DIFF
--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -132,11 +132,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "function_codebuil
   }
 }
 
-resource "aws_s3_bucket_acl" "function_codebuild_cache" {
-  bucket = aws_s3_bucket.function_codebuild_cache.bucket
-  acl    = "private"
-}
-
 # CodeBuild Project
 resource "aws_codebuild_project" "codebuild_project" {
   name         = "${var.function_prefix}-${var.environment}-codebuild-project"

--- a/modules/codepipeline_multi_stage/main.tf
+++ b/modules/codepipeline_multi_stage/main.tf
@@ -77,11 +77,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "function_codepipe
   }
 }
 
-resource "aws_s3_bucket_acl" "function_codepipeline_source_packages" {
-  bucket = aws_s3_bucket.function_codepipeline_source_packages.bucket
-  acl    = "private"
-}
-
 # CodePipeline Project
 resource "aws_codepipeline" "codepipeline_project" {
   name     = "${var.function_prefix}-codepipeline"

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -9,11 +9,6 @@ resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   }
 }
 
-resource "aws_s3_bucket_acl" "function_codepipeline_source_packages" {
-  bucket = aws_s3_bucket.function_codepipeline_source_packages.bucket
-  acl    = "private"
-}
-
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
@@ -23,9 +18,4 @@ resource "aws_s3_bucket" "function_codebuild_cache" {
     Env      = var.environment
     Service  = var.function_name
   }
-}
-
-resource "aws_s3_bucket_acl" "function_codebuild_cache" {
-  bucket = aws_s3_bucket.function_codebuild_cache.bucket
-  acl    = "private"
 }


### PR DESCRIPTION
Terraform is throwing errors saying ACLs are not permitted on the buckets, as we're setting this to private this is likely not needed anyway. This PR removes the ACL resource blocks to clear this error.