### PR TITLE
adding default tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,5 @@
 provider "aws" {
   region = var.region
-  default_tags {
-    tags = local.mandatory_tags {
-    }
-  }
-}
-
-locals {
-  mandatory_tags = {
-    Env       = var.environment
-    Platform  = var.environment
-    Terraform = "true"
-    Team      = var.team
-    Workspace = terraform.workspace
-    Service   = var.function_name
-  }
 }
 ##########
 ### S3 ###

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,20 @@
 provider "aws" {
   region = var.region
+  default_tags {
+    tags = local.mandatory_tags {
+    }
+  }
+}
+
+locals {
+  mandatory_tags = {
+    Env       = var.environment
+    Platform  = var.platform
+    Terraform = "true"
+    Team      = "polaris"
+    Workspace = terraform.workspace
+    Service   = var.function_name
+  }
 }
 ##########
 ### S3 ###
@@ -135,3 +150,5 @@ module "iam" {
   use_api_auth       = var.use_api_auth
   remote_account_id  = var.remote_account_id
 }
+
+

--- a/main.tf
+++ b/main.tf
@@ -4,127 +4,98 @@ provider "aws" {
 ##########
 ### S3 ###
 ##########
-
 module "s3" {
   source                  = "./modules/s3"
   function_name           = var.function_name
   function_prefix         = var.function_prefix
   region                  = var.region
-  platform                = var.platform
   environment             = var.environment
   use_codepipeline_bucket = var.use_codepipeline_bucket
+  mandatory_tags          = var.mandatory_tags
 }
 
 #################
 ### CodeBuild ###
 #################
-/*
 module "codebuild" {
-  source                       = "./modules/codebuild"
-  function_name                = var.function_name
-  function_prefix              = var.function_prefix
-  aws_account_number           = var.aws_account_number
-  region                       = var.region
-  platform                     = var.platform
-  environment                  = var.environment
-
-  environment_image            = var.environment_image
-  base_os_image                = var.base_os_image
-  environment_variables        = var.environment_variables
-  use_api_auth                 = var.use_api_auth
-  buildspec_name               = var.buildspec_name
-
-  kms_key_arn                  = module.ssm.kms_key_arn
-}
-*/
-module "codebuild" {
-  source              = "./modules/codebuild"
-  function_name       = var.function_name
-  function_prefix     = var.function_prefix
-  aws_account_number  = var.aws_account_number
-  remote_account_id   = var.remote_account_id
-  remote_account_role = var.remote_account_role
-  region              = var.region
-  platform            = var.platform
-  environment         = var.environment
-
+  source                = "./modules/codebuild"
+  function_name         = var.function_name
+  function_prefix       = var.function_prefix
+  aws_account_number    = var.aws_account_number
+  remote_account_id     = var.remote_account_id
+  remote_account_role   = var.remote_account_role
+  region                = var.region
+  environment           = var.environment
   environment_image     = var.environment_image
   base_os_image         = var.base_os_image
   environment_variables = var.environment_variables
   use_api_auth          = var.use_api_auth
   use_cross_account     = var.use_cross_account
   buildspec_name        = var.buildspec_name
-
-  kms_key_arn = module.ssm.kms_key_arn
+  kms_key_arn           = module.ssm.kms_key_arn
+  mandatory_tags        = var.mandatory_tags
 }
 
 ####################
 ### CodePipeline ###
 ####################
-
 module "codepipeline" {
-  source          = "./modules/codepipeline"
-  function_name   = var.function_name
-  function_prefix = var.function_prefix
-  region          = var.region
-  platform        = var.platform
-  environment     = var.environment
-
-  github_base_url     = var.github_base_url
-  github_auth_token   = var.github_auth_token
-  github_organization = var.github_organization
-  github_repo         = var.github_repo
-  github_branch       = var.github_branch
-  webhook_ip_range    = var.webhook_ip_range
-  webhook_secret      = var.webhook_secret
-
+  source               = "./modules/codepipeline"
+  function_name        = var.function_name
+  function_prefix      = var.function_prefix
+  region               = var.region
+  environment          = var.environment
+  github_base_url      = var.github_base_url
+  github_auth_token    = var.github_auth_token
+  github_organization  = var.github_organization
+  github_repo          = var.github_repo
+  github_branch        = var.github_branch
+  webhook_ip_range     = var.webhook_ip_range
+  webhook_secret       = var.webhook_secret
   s3_source_bucket_id  = module.s3.s3_source_bucket_id
   s3_source_bucket_arn = module.s3.s3_source_bucket_arn
+  mandatory_tags       = var.mandatory_tags
 }
 
 module "codepipeline_ms" {
-  source          = "./modules/codepipeline_multi_stage"
-  function_name   = var.function_name
-  function_prefix = var.function_prefix
-  region          = var.region
-  platform        = var.platform
-  environment_1   = var.environment_1
-  environment_2   = var.environment_2
-  environment_3   = var.environment_3
-
-  github_base_url     = var.github_base_url
-  github_auth_token   = var.github_auth_token
-  github_organization = var.github_organization
-  github_repo         = var.github_repo
-  github_branch       = var.github_branch
-  webhook_ip_range    = var.webhook_ip_range
-  webhook_secret      = var.webhook_secret
-
-  component_name_1 = var.component_name_1
-  component_name_2 = var.component_name_2
-  component_name_3 = var.component_name_3
+  source                  = "./modules/codepipeline_multi_stage"
+  function_name           = var.function_name
+  function_prefix         = var.function_prefix
+  region                  = var.region
+  environment_1           = var.environment_1
+  environment_2           = var.environment_2
+  environment_3           = var.environment_3
+  github_base_url         = var.github_base_url
+  github_auth_token       = var.github_auth_token
+  github_organization     = var.github_organization
+  github_repo             = var.github_repo
+  github_branch           = var.github_branch
+  codestar_connection_arn = var.codestar_connection_arn
+  webhook_ip_range        = var.webhook_ip_range
+  webhook_secret          = var.webhook_secret
+  component_name_1        = var.component_name_1
+  component_name_2        = var.component_name_2
+  component_name_3        = var.component_name_3
+  mandatory_tags          = var.mandatory_tags
 }
 
 ###########
 ### SSM ###
 ###########
-
 module "ssm" {
   source          = "./modules/ssm"
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.platform
   environment     = var.environment
-
-  use_api_auth   = var.use_api_auth
-  api_auth_token = var.api_auth_token
+  use_api_auth    = var.use_api_auth
+  api_auth_token  = var.api_auth_token
+  mandatory_tags  = var.mandatory_tags
 }
 
 ###########
 ### IAM ###
 ###########
-
 module "iam" {
   source             = "./modules/iam"
   function_prefix    = var.function_prefix
@@ -134,4 +105,5 @@ module "iam" {
   kms_key_arn        = module.ssm.kms_key_arn
   use_api_auth       = var.use_api_auth
   remote_account_id  = var.remote_account_id
+  mandatory_tags     = var.mandatory_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "s3" {
   function_name           = var.function_name
   function_prefix         = var.function_prefix
   region                  = var.region
-  platform                = var.environment
+  platform                = var.platform
   environment             = var.environment
   use_codepipeline_bucket = var.use_codepipeline_bucket
 }
@@ -25,7 +25,7 @@ module "codebuild" {
   function_prefix              = var.function_prefix
   aws_account_number           = var.aws_account_number
   region                       = var.region
-  platform                     = var.environment
+  platform                     = var.platform
   environment                  = var.environment
 
   environment_image            = var.environment_image
@@ -45,7 +45,7 @@ module "codebuild" {
   remote_account_id   = var.remote_account_id
   remote_account_role = var.remote_account_role
   region              = var.region
-  platform            = var.environment
+  platform            = var.platform
   environment         = var.environment
 
   environment_image     = var.environment_image
@@ -67,7 +67,7 @@ module "codepipeline" {
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.environment
+  platform        = var.platform
   environment     = var.environment
 
   github_base_url     = var.github_base_url
@@ -87,7 +87,7 @@ module "codepipeline_ms" {
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.environment
+  platform        = var.platform
   environment_1   = var.environment_1
   environment_2   = var.environment_2
   environment_3   = var.environment_3
@@ -114,7 +114,7 @@ module "ssm" {
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.environment
+  platform        = var.platform
   environment     = var.environment
 
   use_api_auth   = var.use_api_auth

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
     Env       = var.environment
     Platform  = var.platform
     Terraform = "true"
-    Team      = "polaris"
+    Team      = var.team
     Workspace = terraform.workspace
     Service   = var.function_name
   }

--- a/main.tf
+++ b/main.tf
@@ -135,5 +135,3 @@ module "iam" {
   use_api_auth       = var.use_api_auth
   remote_account_id  = var.remote_account_id
 }
-
-

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 locals {
   mandatory_tags = {
     Env       = var.environment
-    Platform  = var.platform
+    Platform  = var.environment
     Terraform = "true"
     Team      = var.team
     Workspace = terraform.workspace
@@ -25,7 +25,7 @@ module "s3" {
   function_name           = var.function_name
   function_prefix         = var.function_prefix
   region                  = var.region
-  platform                = var.platform
+  platform                = var.environment
   environment             = var.environment
   use_codepipeline_bucket = var.use_codepipeline_bucket
 }
@@ -40,7 +40,7 @@ module "codebuild" {
   function_prefix              = var.function_prefix
   aws_account_number           = var.aws_account_number
   region                       = var.region
-  platform                     = var.platform
+  platform                     = var.environment
   environment                  = var.environment
 
   environment_image            = var.environment_image
@@ -60,7 +60,7 @@ module "codebuild" {
   remote_account_id   = var.remote_account_id
   remote_account_role = var.remote_account_role
   region              = var.region
-  platform            = var.platform
+  platform            = var.environment
   environment         = var.environment
 
   environment_image     = var.environment_image
@@ -82,7 +82,7 @@ module "codepipeline" {
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.platform
+  platform        = var.environment
   environment     = var.environment
 
   github_base_url     = var.github_base_url
@@ -102,7 +102,7 @@ module "codepipeline_ms" {
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.platform
+  platform        = var.environment
   environment_1   = var.environment_1
   environment_2   = var.environment_2
   environment_3   = var.environment_3
@@ -129,7 +129,7 @@ module "ssm" {
   function_name   = var.function_name
   function_prefix = var.function_prefix
   region          = var.region
-  platform        = var.platform
+  platform        = var.environment
   environment     = var.environment
 
   use_api_auth   = var.use_api_auth

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -1,23 +1,23 @@
 # IAM Role
 resource "aws_iam_role" "codebuild_role" {
-  name               = "${var.function_prefix}-${var.stage}-codebuild-role"
+  name               = "${var.function_prefix}-${var.environment}-codebuild-role"
   assume_role_policy = file("${path.module}/codebuild-role-template.json")
 }
 
 # IAM polices
 resource "aws_iam_role_policy" "codebuild_policy" {
-  name = "${var.function_prefix}-${var.stage}-codebuild-base-policy"
+  name = "${var.function_prefix}-${var.environment}-codebuild-base-policy"
   role = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/codebuild-role-policy-template.json", {
     aws_account_number = var.aws_account_number,
     region             = var.region,
-    environment        = var.stage,
+    environment        = var.environment,
     function_prefix    = var.function_prefix
   })
 }
 
 resource "aws_iam_role_policy" "codebuild_policy_2" {
-  name   = "${var.function_prefix}-${var.stage}-codebuild-serverless-policy"
+  name   = "${var.function_prefix}-${var.environment}-codebuild-serverless-policy"
   role   = aws_iam_role.codebuild_role.id
   policy = file("${path.module}/serverless-role-policy-template.json")
 }
@@ -25,19 +25,19 @@ resource "aws_iam_role_policy" "codebuild_policy_2" {
 resource "aws_iam_role_policy" "codebuild_policy_3" {
   count = var.use_api_auth ? 1 : 0
 
-  name = "${var.function_prefix}-${var.stage}-codebuild-ssm-policy"
+  name = "${var.function_prefix}-${var.environment}-codebuild-ssm-policy"
   role = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/ssm-role-policy-template.json", {
     aws_account_number = var.aws_account_number,
     region             = var.region,
-    environment        = var.stage,
+    environment        = var.environment,
     function_prefix    = var.function_prefix
     kms_key_arn        = var.kms_key_arn
   })
 }
 
 resource "aws_iam_role_policy" "codebuild_policy_4" {
-  name = "${var.function_prefix}-${var.stage}-remote-codebuild-policy"
+  name = "${var.function_prefix}-${var.environment}-remote-codebuild-policy"
   role = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/codebuild-cross-account-template.json", {
     remote_account      = var.remote_account_id
@@ -100,17 +100,17 @@ data "aws_iam_policy_document" "codebuild_vpc_policy" {
 }
 
 resource "aws_iam_role_policy" "codebuild_vpc_access" {
-  name   = "${var.function_prefix}-${var.stage}-codebuild-vpc"
+  name   = "${var.function_prefix}-${var.environment}-codebuild-vpc"
   role   = aws_iam_role.codebuild_role.id
   policy = data.aws_iam_policy_document.codebuild_vpc_policy.json
 }
 
 # CodeBuild Cache Bucket
 resource "aws_s3_bucket" "function_codebuild_cache" {
-  bucket = "${var.function_prefix}-${var.stage}-codebuild-cache"
+  bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
   tags = { 
-    Name = "${var.function_name} ${var.stage} CodeBuild cache" 
+    Name = "${var.function_name} ${var.environment} CodeBuild cache" 
   }
 }
 
@@ -127,7 +127,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "function_codebuil
 
 # CodeBuild Project
 resource "aws_codebuild_project" "codebuild_project" {
-  name         = "${var.function_prefix}-${var.stage}-codebuild-project"
+  name         = "${var.function_prefix}-${var.environment}-codebuild-project"
   service_role = aws_iam_role.codebuild_role.arn
 
   artifacts {
@@ -136,7 +136,7 @@ resource "aws_codebuild_project" "codebuild_project" {
 
   cache {
     type     = "S3"
-    location = "${var.function_prefix}-${var.stage}-codebuild-cache"
+    location = "${var.function_prefix}-${var.environment}-codebuild-cache"
   }
 
   environment {

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -2,11 +2,6 @@
 resource "aws_iam_role" "codebuild_role" {
   name               = "${var.function_prefix}-${var.environment}-codebuild-role"
   assume_role_policy = file("${path.module}/codebuild-role-template.json")
-  tags = {
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
 }
 
 # IAM polices
@@ -114,11 +109,9 @@ resource "aws_iam_role_policy" "codebuild_vpc_access" {
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
-  tags = {
-    Name        = "${var.function_name} ${var.environment} CodeBuild cache"
-    Platform    = var.platform
-    Environment = var.environment
-  }
+  tags = merge(local.mandatory_tags, 
+    { Name = "${var.function_name} ${var.environment} CodeBuild cache" }
+  )
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "function_codebuild_cache" {
@@ -166,12 +159,6 @@ resource "aws_codebuild_project" "codebuild_project" {
     type      = "CODEPIPELINE"
     buildspec = var.buildspec_name
   }
-  tags = {
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
-
   # include the vpc config if the vpc_id is set
   dynamic "vpc_config" {
     for_each = var.vpc_id != "" ? [1] : []

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -2,6 +2,10 @@
 resource "aws_iam_role" "codebuild_role" {
   name               = "${var.function_prefix}-${var.environment}-codebuild-role"
   assume_role_policy = file("${path.module}/codebuild-role-template.json")
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codebuild-role"
+  })
 }
 
 # IAM polices
@@ -24,9 +28,8 @@ resource "aws_iam_role_policy" "codebuild_policy_2" {
 
 resource "aws_iam_role_policy" "codebuild_policy_3" {
   count = var.use_api_auth ? 1 : 0
-
-  name = "${var.function_prefix}-${var.environment}-codebuild-ssm-policy"
-  role = aws_iam_role.codebuild_role.id
+  name  = "${var.function_prefix}-${var.environment}-codebuild-ssm-policy"
+  role  = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/ssm-role-policy-template.json", {
     aws_account_number = var.aws_account_number,
     region             = var.region,
@@ -109,9 +112,9 @@ resource "aws_iam_role_policy" "codebuild_vpc_access" {
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
-  tags = { 
-    Name = "${var.function_name} ${var.environment} CodeBuild cache" 
-  }
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_name} ${var.environment} CodeBuild cache"
+  })
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "function_codebuild_cache" {
@@ -171,4 +174,7 @@ resource "aws_codebuild_project" "codebuild_project" {
     }
   }
 
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codebuild-project"
+  })
 }

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -1,23 +1,23 @@
 # IAM Role
 resource "aws_iam_role" "codebuild_role" {
-  name               = "${var.function_prefix}-${var.environment}-codebuild-role"
+  name               = "${var.function_prefix}-${var.stage}-codebuild-role"
   assume_role_policy = file("${path.module}/codebuild-role-template.json")
 }
 
 # IAM polices
 resource "aws_iam_role_policy" "codebuild_policy" {
-  name = "${var.function_prefix}-${var.environment}-codebuild-base-policy"
+  name = "${var.function_prefix}-${var.stage}-codebuild-base-policy"
   role = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/codebuild-role-policy-template.json", {
     aws_account_number = var.aws_account_number,
     region             = var.region,
-    environment        = var.environment,
+    environment        = var.stage,
     function_prefix    = var.function_prefix
   })
 }
 
 resource "aws_iam_role_policy" "codebuild_policy_2" {
-  name   = "${var.function_prefix}-${var.environment}-codebuild-serverless-policy"
+  name   = "${var.function_prefix}-${var.stage}-codebuild-serverless-policy"
   role   = aws_iam_role.codebuild_role.id
   policy = file("${path.module}/serverless-role-policy-template.json")
 }
@@ -25,19 +25,19 @@ resource "aws_iam_role_policy" "codebuild_policy_2" {
 resource "aws_iam_role_policy" "codebuild_policy_3" {
   count = var.use_api_auth ? 1 : 0
 
-  name = "${var.function_prefix}-${var.environment}-codebuild-ssm-policy"
+  name = "${var.function_prefix}-${var.stage}-codebuild-ssm-policy"
   role = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/ssm-role-policy-template.json", {
     aws_account_number = var.aws_account_number,
     region             = var.region,
-    environment        = var.environment,
+    environment        = var.stage,
     function_prefix    = var.function_prefix
     kms_key_arn        = var.kms_key_arn
   })
 }
 
 resource "aws_iam_role_policy" "codebuild_policy_4" {
-  name = "${var.function_prefix}-${var.environment}-remote-codebuild-policy"
+  name = "${var.function_prefix}-${var.stage}-remote-codebuild-policy"
   role = aws_iam_role.codebuild_role.id
   policy = templatefile("${path.module}/codebuild-cross-account-template.json", {
     remote_account      = var.remote_account_id
@@ -100,17 +100,17 @@ data "aws_iam_policy_document" "codebuild_vpc_policy" {
 }
 
 resource "aws_iam_role_policy" "codebuild_vpc_access" {
-  name   = "${var.function_prefix}-${var.environment}-codebuild-vpc"
+  name   = "${var.function_prefix}-${var.stage}-codebuild-vpc"
   role   = aws_iam_role.codebuild_role.id
   policy = data.aws_iam_policy_document.codebuild_vpc_policy.json
 }
 
 # CodeBuild Cache Bucket
 resource "aws_s3_bucket" "function_codebuild_cache" {
-  bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
+  bucket = "${var.function_prefix}-${var.stage}-codebuild-cache"
 
   tags = { 
-    Name = "${var.function_name} ${var.environment} CodeBuild cache" 
+    Name = "${var.function_name} ${var.stage} CodeBuild cache" 
   }
 }
 
@@ -127,7 +127,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "function_codebuil
 
 # CodeBuild Project
 resource "aws_codebuild_project" "codebuild_project" {
-  name         = "${var.function_prefix}-${var.environment}-codebuild-project"
+  name         = "${var.function_prefix}-${var.stage}-codebuild-project"
   service_role = aws_iam_role.codebuild_role.arn
 
   artifacts {
@@ -136,7 +136,7 @@ resource "aws_codebuild_project" "codebuild_project" {
 
   cache {
     type     = "S3"
-    location = "${var.function_prefix}-${var.environment}-codebuild-cache"
+    location = "${var.function_prefix}-${var.stage}-codebuild-cache"
   }
 
   environment {

--- a/modules/codebuild/main.tf
+++ b/modules/codebuild/main.tf
@@ -109,9 +109,9 @@ resource "aws_iam_role_policy" "codebuild_vpc_access" {
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
-  tags = merge(local.mandatory_tags, 
-    { Name = "${var.function_name} ${var.environment} CodeBuild cache" }
-  )
+  tags = { 
+    Name = "${var.function_name} ${var.environment} CodeBuild cache" 
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "function_codebuild_cache" {

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -22,6 +22,10 @@ variable "environment" {
   description = "Environment name"
 }
 
+vaible "stage" {
+  description = "codebuild stage name"
+}
+
 variable "environment_image" {
   description = "Which Docker image to use as your build environment"
   type        = string

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -20,7 +20,7 @@ variable "environment" {
 
 variable "stage" {
   description = "codebuild stage name"
-  default = null
+  default     = null
 }
 
 variable "environment_image" {

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -24,6 +24,7 @@ variable "environment" {
 
 variable "stage" {
   description = "codebuild stage name"
+  default = null
 }
 
 variable "environment_image" {

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -22,6 +22,10 @@ variable "environment" {
   description = "Environment name"
 }
 
+variable "stage" {
+  description = "stage name"
+}
+
 variable "environment_image" {
   description = "Which Docker image to use as your build environment"
   type        = string

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -14,10 +14,6 @@ variable "region" {
   description = "The AWS Region to create the lambda function in"
 }
 
-variable "platform" {
-  description = "Platform identifier."
-}
-
 variable "environment" {
   description = "Environment name"
 }
@@ -86,4 +82,10 @@ variable "vpc_id" {
 variable "public_security_group_id" {
   description = "Generated from configured security groups, common reference as aws_security_group.outbound.id"
   default     = ""
+}
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
 }

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -22,7 +22,7 @@ variable "environment" {
   description = "Environment name"
 }
 
-vaible "stage" {
+variable "stage" {
   description = "codebuild stage name"
 }
 

--- a/modules/codebuild/variables.tf
+++ b/modules/codebuild/variables.tf
@@ -22,10 +22,6 @@ variable "environment" {
   description = "Environment name"
 }
 
-variable "stage" {
-  description = "stage name"
-}
-
 variable "environment_image" {
   description = "Which Docker image to use as your build environment"
   type        = string

--- a/modules/codepipeline/main.tf
+++ b/modules/codepipeline/main.tf
@@ -7,6 +7,10 @@ provider "github" {
 resource "aws_iam_role" "codepipeline_role" {
   name               = "${var.function_prefix}-${var.environment}-codepipeline-role"
   assume_role_policy = file("${path.module}/codepipeline-role-policy-template.json")
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codepipeline-role"
+  })
 }
 
 resource "aws_iam_role_policy" "pipeline_policy" {
@@ -40,6 +44,10 @@ resource "aws_codepipeline_webhook" "codepipeline_webhook" {
     json_path    = "$.ref"
     match_equals = "refs/heads/${var.github_branch}"
   }
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codepipeline-webhook"
+  })
 }
 
 # GitHub Webhook
@@ -107,4 +115,8 @@ resource "aws_codepipeline" "codepipeline_project" {
       }
     }
   }
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codepipeline"
+  })
 }

--- a/modules/codepipeline/main.tf
+++ b/modules/codepipeline/main.tf
@@ -7,11 +7,6 @@ provider "github" {
 resource "aws_iam_role" "codepipeline_role" {
   name               = "${var.function_prefix}-${var.environment}-codepipeline-role"
   assume_role_policy = file("${path.module}/codepipeline-role-policy-template.json")
-  tags = {
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
 }
 
 resource "aws_iam_role_policy" "pipeline_policy" {
@@ -44,12 +39,6 @@ resource "aws_codepipeline_webhook" "codepipeline_webhook" {
   filter {
     json_path    = "$.ref"
     match_equals = "refs/heads/${var.github_branch}"
-  }
-
-  tags = {
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
   }
 }
 
@@ -117,10 +106,5 @@ resource "aws_codepipeline" "codepipeline_project" {
         PrimarySource = "source_output"
       }
     }
-  }
-  tags = {
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
   }
 }

--- a/modules/codepipeline/variables.tf
+++ b/modules/codepipeline/variables.tf
@@ -10,10 +10,6 @@ variable "region" {
   description = "The AWS Region to create the lambda function in"
 }
 
-variable "platform" {
-  description = "Platform identifier."
-}
-
 variable "environment" {
   description = "Environment name"
 }
@@ -52,4 +48,10 @@ variable "webhook_secret" {
 
 variable "webhook_ip_range" {
   description = "A list of IPs allowed to trigger the webhook"
+}
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
 }

--- a/modules/codepipeline_multi_stage/main.tf
+++ b/modules/codepipeline_multi_stage/main.tf
@@ -60,9 +60,9 @@ resource "github_repository_webhook" "github_webhook" {
 resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   bucket = "${var.function_prefix}-codepipeline-source-packages"
 
-  tags = merge(local.mandatory_tags,
-    {  Name = "${var.function_name} CodePipeline source packages" }
-  )
+  tags = {  
+    Name = "${var.function_name} CodePipeline source packages" 
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "function_codepipeline_source_packages" {

--- a/modules/codepipeline_multi_stage/main.tf
+++ b/modules/codepipeline_multi_stage/main.tf
@@ -60,10 +60,9 @@ resource "github_repository_webhook" "github_webhook" {
 resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   bucket = "${var.function_prefix}-codepipeline-source-packages"
 
-  tags = {
-    Name     = "${var.function_name} CodePipeline source packages"
-    Platform = var.platform
-  }
+  tags = merge(local.mandatory_tags,
+    {  Name = "${var.function_name} CodePipeline source packages" }
+  )
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "function_codepipeline_source_packages" {

--- a/modules/codepipeline_multi_stage/main.tf
+++ b/modules/codepipeline_multi_stage/main.tf
@@ -7,6 +7,10 @@ provider "github" {
 resource "aws_iam_role" "codepipeline_role" {
   name               = "${var.function_prefix}-codepipeline-role"
   assume_role_policy = file("${path.module}/codepipeline-role-policy-template.json")
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-codepipeline-role"
+  })
 }
 
 resource "aws_iam_role_policy" "pipeline_policy" {
@@ -40,6 +44,10 @@ resource "aws_codepipeline_webhook" "codepipeline_webhook" {
     json_path    = "$.ref"
     match_equals = "refs/heads/${var.github_branch}"
   }
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-codepipeline-webhook"
+  })
 }
 
 # GitHub Webhook
@@ -60,9 +68,9 @@ resource "github_repository_webhook" "github_webhook" {
 resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   bucket = "${var.function_prefix}-codepipeline-source-packages"
 
-  tags = {  
-    Name = "${var.function_name} CodePipeline source packages" 
-  }
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-codepipeline-source-packages"
+  })
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "function_codepipeline_source_packages" {
@@ -244,4 +252,8 @@ resource "aws_codepipeline" "codepipeline_project" {
       }
     }
   }
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-codepipeline"
+  })
 }

--- a/modules/codepipeline_multi_stage/variables.tf
+++ b/modules/codepipeline_multi_stage/variables.tf
@@ -10,10 +10,6 @@ variable "region" {
   description = "The AWS Region to create the lambda function in"
 }
 
-variable "platform" {
-  description = "Platform identifier."
-}
-
 variable "environment_1" {
   description = "Environment name stage/dev"
 }
@@ -93,4 +89,10 @@ variable "disable_integration_test" {
 variable "disable_integration_II_test" {
   description = "Disable Integration II Test Stage"
   default     = true
+}
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
 }

--- a/modules/codepipeline_multi_stage/versions.tf
+++ b/modules/codepipeline_multi_stage/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source                = "hashicorp/aws"
       configuration_aliases = [aws]
     }
     github = {

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -5,6 +5,10 @@ resource "aws_iam_role" "remote_codebuild_role" {
     aws_account_number = var.aws_account_number,
     local_account_role = "${var.function_prefix}-${var.environment}-codebuild-role"
   })
+
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-remote-codebuild-role"
+  })
 }
 
 # IAM polices
@@ -20,9 +24,8 @@ resource "aws_iam_role_policy" "remote_codebuild_policy" {
 
 resource "aws_iam_role_policy" "remote_codebuild_policy_2" {
   count = var.use_api_auth ? 1 : 0
-
-  name = "${var.function_prefix}-${var.environment}-codebuild-ssm-policy"
-  role = aws_iam_role.remote_codebuild_role.id
+  name  = "${var.function_prefix}-${var.environment}-codebuild-ssm-policy"
+  role  = aws_iam_role.remote_codebuild_role.id
   policy = templatefile("${path.module}/ssm-role-policy-template.json", {
     aws_account_number = var.remote_account_id,
     region             = var.region,
@@ -30,6 +33,7 @@ resource "aws_iam_role_policy" "remote_codebuild_policy_2" {
     function_prefix    = var.function_prefix
     kms_key_arn        = var.kms_key_arn
   })
+
   depends_on = [
     aws_iam_role.remote_codebuild_role,
   ]

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -26,3 +26,9 @@ variable "use_api_auth" {
 variable "kms_key_arn" {
   description = "The key used for decrypting secrets from secrets manager"
 }
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
+}

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source                = "hashicorp/aws"
       configuration_aliases = [aws]
     }
   }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,15 +1,15 @@
 resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   bucket = "${var.function_prefix}-${var.environment}-codepipeline-source-packages"
 
-  tags = { 
-    Name = "${var.function_name} ${var.environment} CodePipeline source packages" 
-  }
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codepipeline-source-packages"
+  })
 }
 
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
-  tags = { 
-    Name = "${var.function_name} ${var.environment} CodeBuild cache" 
-  }
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-codebuild-cache"
+  })
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,15 +1,15 @@
 resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   bucket = "${var.function_prefix}-${var.environment}-codepipeline-source-packages"
 
-  tags = merge(local.mandatory_tags,
-    { Name = "${var.function_name} ${var.environment} CodePipeline source packages" }
-  )
+  tags = { 
+    Name = "${var.function_name} ${var.environment} CodePipeline source packages" 
+  }
 }
 
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
-  tags = merge(local.mandatory_tags,
-    { Name = "${var.function_name} ${var.environment} CodeBuild cache" }
-  )
+  tags = { 
+    Name = "${var.function_name} ${var.environment} CodeBuild cache" 
+  }
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,21 +1,15 @@
 resource "aws_s3_bucket" "function_codepipeline_source_packages" {
   bucket = "${var.function_prefix}-${var.environment}-codepipeline-source-packages"
 
-  tags = {
-    Name     = "${var.function_name} ${var.environment} CodePipeline source packages"
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
+  tags = merge(local.mandatory_tags,
+    { Name = "${var.function_name} ${var.environment} CodePipeline source packages" }
+  )
 }
 
 resource "aws_s3_bucket" "function_codebuild_cache" {
   bucket = "${var.function_prefix}-${var.environment}-codebuild-cache"
 
-  tags = {
-    Name     = "${var.function_name} ${var.environment} CodeBuild cache"
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
+  tags = merge(local.mandatory_tags,
+    { Name = "${var.function_name} ${var.environment} CodeBuild cache" }
+  )
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -10,14 +10,16 @@ variable "region" {
   description = "The AWS Region to create the lambda function in"
 }
 
-variable "platform" {
-  description = "Platform identifier."
-}
-
 variable "environment" {
   description = "Environment name"
 }
 
 variable "use_codepipeline_bucket" {
   description = "Whether or not you require the codepipeline bucket numerous times - if you just require another codebuild cache bucket - specifiy false"
+}
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
 }

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -12,31 +12,28 @@ resource "random_password" "api_auth_token" {
 }
 
 resource "aws_kms_key" "kms_key" {
-  count = var.use_api_auth ? 1 : 0
-
+  count       = var.use_api_auth ? 1 : 0
   description = var.function_name
 
-  tags = {
-    Name = "${var.function_name} ${var.environment} API Key" 
-  }
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_name} ${var.environment} API Key"
+  })
 }
 
 resource "aws_kms_alias" "kms_alias" {
-  count = var.use_api_auth ? 1 : 0
-
+  count         = var.use_api_auth ? 1 : 0
   name          = "alias/${var.function_prefix}-${var.environment}"
   target_key_id = aws_kms_key.kms_key[0].key_id
 }
 
 resource "aws_ssm_parameter" "ssm_ps_prod" {
-  count = var.use_api_auth ? 1 : 0
-
+  count  = var.use_api_auth ? 1 : 0
   name   = "${var.function_prefix}-${var.environment}-rest-api-key"
   type   = "SecureString"
   key_id = aws_kms_key.kms_key[0].arn
   value  = local.api_auth_token
 
-  tags = { 
-     Name = "${var.function_name} ${var.environment} API Key" 
-  }
+  tags = merge(var.mandatory_tags, {
+    Name = "${var.function_prefix}-${var.environment}-rest-api-key"
+  })
 }

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -16,12 +16,9 @@ resource "aws_kms_key" "kms_key" {
 
   description = var.function_name
 
-  tags = {
-    Name     = "${var.function_name} ${var.environment} API Key"
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
+  tags = merge(local.mandatory_tags, 
+    { Name = "${var.function_name} ${var.environment} API Key" }
+  )
 }
 
 resource "aws_kms_alias" "kms_alias" {
@@ -39,10 +36,7 @@ resource "aws_ssm_parameter" "ssm_ps_prod" {
   key_id = aws_kms_key.kms_key[0].arn
   value  = local.api_auth_token
 
-  tags = {
-    Name     = "${var.function_name} ${var.environment} API Key"
-    Platform = var.platform
-    Env      = var.environment
-    Service  = var.function_name
-  }
+  tags = merge(local.mandatory_tags, 
+    { Name = "${var.function_name} ${var.environment} API Key" }
+  )
 }

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -36,7 +36,7 @@ resource "aws_ssm_parameter" "ssm_ps_prod" {
   key_id = aws_kms_key.kms_key[0].arn
   value  = local.api_auth_token
 
-  tags = merge(local.mandatory_tags, 
-    { Name = "${var.function_name} ${var.environment} API Key" }
-  )
+  tags = { 
+     Name = "${var.function_name} ${var.environment} API Key" 
+  }
 }

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -16,9 +16,9 @@ resource "aws_kms_key" "kms_key" {
 
   description = var.function_name
 
-  tags = merge(local.mandatory_tags, 
-    { Name = "${var.function_name} ${var.environment} API Key" }
-  )
+  tags = {
+    Name = "${var.function_name} ${var.environment} API Key" 
+  }
 }
 
 resource "aws_kms_alias" "kms_alias" {

--- a/modules/ssm/variables.tf
+++ b/modules/ssm/variables.tf
@@ -10,10 +10,6 @@ variable "region" {
   description = "The AWS Region to create the lambda function in"
 }
 
-variable "platform" {
-  description = "Platform identifier."
-}
-
 variable "environment" {
   description = "Environment name"
 }
@@ -25,4 +21,10 @@ variable "use_api_auth" {
 variable "api_auth_token" {
   description = "The value of the API authentication key"
   default     = ""
+}
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
 }

--- a/modules/ssm/versions.tf
+++ b/modules/ssm/versions.tf
@@ -6,7 +6,7 @@ terraform {
       version = "~> 3.1"
     }
     aws = {
-      source = "hashicorp/aws"
+      source                = "hashicorp/aws"
       configuration_aliases = [aws]
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,10 @@ variable "platform" {
   description = "Platform identifier."
 }
 
+variable "stage" {
+  default = ""
+}
+
 variable "remote_account_access_key" {
   type        = string
   description = "The access key used to access a remote account"

--- a/variables.tf
+++ b/variables.tf
@@ -173,3 +173,14 @@ variable "environment_3" {
   type        = string
   description = "Environment name prod"
 }
+
+variable "mandatory_tags" {
+  description = "Standard tags applied to all resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "codestar_connection_arn" {
+  type        = string
+  description = "Codestar_connection_arn"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -29,10 +29,6 @@ variable "platform" {
   description = "Platform identifier."
 }
 
-variable "stage" {
-  default = ""
-}
-
 variable "remote_account_access_key" {
   type        = string
   description = "The access key used to access a remote account"


### PR DESCRIPTION
Added mandatory_tags to all sub-modules
Removed use of platform variable(used for tagging). This tag will be defaulted from AWS provider config. 
Env Tag value will be defaulted from AWS provider config defined in wcp-services-apps/pipelines/main.tf.
New Tag 3.1.0 will be created after merging this PR. 
TF Plan related to these changes can be observed [here](https://app.terraform.io/app/Immediate-Media/workspaces/wcp-services-apps-pipelines/runs/run-6vuRyxfcpmpDAVK1) 